### PR TITLE
fix DB_URL in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,4 +30,4 @@ KEYCLOAK_CLIENT_SECRET=3f170eea-19e2-43a7-a5cd-9343c6c74b09
 # At the moment only v2 keys are supported
 RECAPTCHA_PUBLIC_KEY=123key123
 
-DB_URL=jdbc:postgresql://wcstore_boilerplate_postgres/wcs
+DB_URL=jdbc:postgresql://wcstore_postgres/wcs


### PR DESCRIPTION
The `.env.example` file had a wrong value for `DB_URL`.

The container name for the postgres service in the `docker-compose.yaml` file is `wcstore_postgres` and the `DB_URL` was not matching that name.

This resulted in a Java traceback when trying to pull up the docker compose environment.